### PR TITLE
Evaluate HOSTNAME on container, not on Docker Host

### DIFF
--- a/labs/01-Verify-Installation/docker-compose.yml
+++ b/labs/01-Verify-Installation/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   kafka:
     image: wurstmeister/kafka:0.10.1.1
     environment:
-      HOSTNAME_COMMAND: "echo $HOSTNAME"
+      HOSTNAME_COMMAND: "echo $$HOSTNAME"
       KAFKA_ADVERTISED_PORT: 9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     depends_on:


### PR DESCRIPTION
Use $$HOSTNAME in docker-compose.yml instead of $HOSTNAME, "escaping" the env var so it is not evaluated on the Docker host. This causes docker-compose to set ' HOSTNAME_COMMAND: "echo $HOSTNAME" ' on the container, so that $HOSTNAME is evaluated there. The result is that the container itself is the advertised host name, which is correct for this lab. With the previous version of the file, $HOSTNAME is evaluated on the Docker Host. Some platforms muddle through with the previous version, but others report LEADER_NOT_AVAILABLE errors.